### PR TITLE
add ability to optionally disabled march=native through patch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,14 @@ include(ExternalProject)
 
 file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/include)
 
+option(OPENGV_BUILD_WITH_MARCH_NATIVE "Enable native build" ON)
+if(OPENGV_BUILD_WITH_MARCH_NATIVE)
+    set(OPENGV_PATCH_COMMAND "")
+else()
+    message(WARNING "Disabling -march=native. Make sure this matches the gtsam config!")
+    set(OPENGV_PATCH_COMMAND git apply ${CMAKE_CURRENT_LIST_DIR}/march_native_disable.patch)
+endif()
+
 ExternalProject_Add(
   opengv_src
   GIT_REPOSITORY https://github.com/laurentkneip/opengv.git
@@ -20,6 +28,7 @@ ExternalProject_Add(
   # Change the path to GTSAM's eigen to your own! ideally use gtsam_catkin...
   # -DEIGEN_INCLUDE_DIR=${CATKIN_DEVEL_PREFIX}/../src/eigen_catkin/include
   # -DEIGEN_INCLUDE_DIRS=${CATKIN_DEVEL_PREFIX}/../src/eigen_catkin/include
+  PATCH_COMMAND ${OPENGV_PATCH_COMMAND}
   BUILD_COMMAND cd ../opengv_src && make -j 8
   INSTALL_COMMAND cd ../opengv_src && make install
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,37 +8,62 @@ include(ExternalProject)
 
 file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/include)
 
+set(APPLY_MARCH_NATIVE_PATCH OFF)
+
 option(OPENGV_BUILD_WITH_MARCH_NATIVE "Enable native build" ON)
-if(OPENGV_BUILD_WITH_MARCH_NATIVE)
-    set(OPENGV_PATCH_COMMAND "")
+find_package(GTSAM QUIET)
+if(NOT TARGET gtsam)
+  if(OPENGV_BUILD_WITH_MARCH_NATIVE)
+    message(
+      WARNING "Enabling -march=native. Make sure this matches the gtsam config!"
+    )
+    set(APPLY_MARCH_NATIVE_PATCH OFF)
+  else()
+    message(
+      WARNING
+        "Disabling -march=native. Make sure this matches the gtsam config!")
+    set(APPLY_MARCH_NATIVE_PATCH ON)
+  endif()
 else()
-    message(WARNING "Disabling -march=native. Make sure this matches the gtsam config!")
-    set(OPENGV_PATCH_COMMAND git apply ${CMAKE_CURRENT_LIST_DIR}/march_native_disable.patch)
+  get_target_property(GTSAM_FLAGS gtsam INTERFACE_COMPILE_OPTIONS)
+  string(FIND "${GTSAM_FLAGS}" "-march=native" MARCH_NATIVE_INDEX)
+  if(${MARCH_NATIVE_INDEX} EQUAL -1)
+    set(APPLY_MARCH_NATIVE_PATCH ON)
+  else()
+    set(APPLY_MARCH_NATIVE_PATCH OFF)
+  endif()
+endif()
+
+if(${APPLY_MARCH_NATIVE_PATCH})
+  message(STATUS "dropping -march=native")
+  set(OPENGV_PATCH_COMMAND git apply
+                           ${CMAKE_CURRENT_LIST_DIR}/march_native_disable.patch)
+else()
+  message(STATUS "keeping -march=native")
+  set(OPENGV_PATCH_COMMAND "")
 endif()
 
 ExternalProject_Add(
   opengv_src
   GIT_REPOSITORY https://github.com/laurentkneip/opengv.git
   GIT_TAG master
-#  GIT_PROGRESS 1
+  # GIT_PROGRESS 1
   UPDATE_COMMAND ""
-  #PATCH_COMMAND patch -p1 < ${CMAKE_SOURCE_DIR}/use_catkinized_eigen.patch
+  # PATCH_COMMAND patch -p1 < ${CMAKE_SOURCE_DIR}/use_catkinized_eigen.patch
   CONFIGURE_COMMAND cd ../opengv_src && cmake . -DCMAKE_BUILD_TYPE=Release
-      -DCMAKE_INSTALL_PREFIX:PATH=${CATKIN_DEVEL_PREFIX}
+                    -DCMAKE_INSTALL_PREFIX:PATH=${CATKIN_DEVEL_PREFIX}
   # Change the path to GTSAM's eigen to your own! ideally use gtsam_catkin...
   # -DEIGEN_INCLUDE_DIR=${CATKIN_DEVEL_PREFIX}/../src/eigen_catkin/include
   # -DEIGEN_INCLUDE_DIRS=${CATKIN_DEVEL_PREFIX}/../src/eigen_catkin/include
   PATCH_COMMAND ${OPENGV_PATCH_COMMAND}
   BUILD_COMMAND cd ../opengv_src && make -j 8
-  INSTALL_COMMAND cd ../opengv_src && make install
-)
+  INSTALL_COMMAND cd ../opengv_src && make install)
 
-install(DIRECTORY ${CATKIN_DEVEL_PREFIX}/include/opengv
-        DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}
-        FILES_MATCHING PATTERN "*.hpp")
+install(
+  DIRECTORY ${CATKIN_DEVEL_PREFIX}/include/opengv
+  DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}
+  FILES_MATCHING
+  PATTERN "*.hpp")
 install(DIRECTORY ${CATKIN_DEVEL_PREFIX}/lib/
         DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
-cs_export(INCLUDE_DIRS ${CATKIN_DEVEL_PREFIX}/include
-          LIBRARIES opengv)
-
-
+cs_export(INCLUDE_DIRS ${CATKIN_DEVEL_PREFIX}/include LIBRARIES opengv)

--- a/march_native_disable.patch
+++ b/march_native_disable.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9660f55..88a7dac 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -35,8 +35,6 @@ ELSE()
+   ELSEIF (CMAKE_SYSTEM_PROCESSOR MATCHES 
+           "(arm)|(ARM)|(armhf)|(ARMHF)|(armel)|(ARMEL)")
+     add_definitions (-march=armv7-a)
+-  ELSE ()
+-    add_definitions (-march=native) #TODO use correct c++11 def once everybody has moved to gcc 4.7 # for now I even removed std=gnu++0x
+   ENDIF()
+   add_definitions (
+     -O3

--- a/package.xml
+++ b/package.xml
@@ -11,5 +11,6 @@
   <buildtool_depend>catkin_simple</buildtool_depend>
 
   <depend>eigen_catkin</depend>
+  <depend>gtsam</depend>
 
 </package>


### PR DESCRIPTION
Allow for the ability to conditionally enable / disable `-march=native` in opengv so it can match the option in gtsam / downstream in kimera-vio.